### PR TITLE
Fix setState() called after dispose()

### DIFF
--- a/lib/gif.dart
+++ b/lib/gif.dart
@@ -299,6 +299,8 @@ class _GifState extends State<Gif> with SingleTickerProviderStateMixin {
         ? Gif.cache.caches[_getImageKey(widget.image)]!
         : await _fetchFrames(widget.image);
 
+    if (!mounted) return;
+
     Gif.cache.caches.putIfAbsent(_getImageKey(widget.image), () => gif);
 
     setState(() {


### PR DESCRIPTION
- Gif loading may start when widget is mounted but can complete when widget is disposed