### PR TITLE
GifController shouldn't be accessed after dispose

### DIFF
--- a/lib/gif.dart
+++ b/lib/gif.dart
@@ -254,7 +254,7 @@ class _GifState extends State<Gif> with SingleTickerProviderStateMixin {
 
   /// Start this gif according to [widget.autostart] and [widget.loop].
   void _autostart() {
-    if (widget.autostart != Autostart.no) {
+    if (mounted && widget.autostart != Autostart.no) {
       _controller..reset();
       if (widget.autostart == Autostart.loop) {
         _controller.repeat();


### PR DESCRIPTION
1. `Gif` widget instantiated 
2. Immediately disposed before `_autostart()` called
3. Exception thrown
```
 'package:flutter/src/animation/animation_controller.dart': Failed assertion: line 772 pos 7: '_ticker != null': AnimationControl...
                                         #0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:51:61)
                                         #1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:40:5)
                                         #2      AnimationController.stop (package:flutter/src/animation/animation_controller.dart:772:7)
                                         #3      AnimationController.value= (package:flutter/src/animation/animation_controller.dart:363:5)
                                         #4      AnimationController.reset (package:flutter/src/animation/animation_controller.dart:384:5)
                                         #5      _GifState._autostart (package:gif/gif.dart:258:20)
                                         #6      _GifState.didChangeDependencies.<anonymous closure> (package:gif/gif.dart:214:35)
                                         #7      _rootRunUnary (dart:async/zone.dart:1434:47)
                                         #8      _CustomZone.runUnary (dart:async/zone.dart:1335:19)
                                         <asynchronous suspension>
```