### PR TITLE
Cache File System Images and also add a parameter to disable caching

### DIFF
--- a/lib/gif.dart
+++ b/lib/gif.dart
@@ -271,9 +271,11 @@ class _GifState extends State<Gif> with SingleTickerProviderStateMixin {
         ? provider.url
         : provider is AssetImage
             ? provider.assetName
-            : provider is MemoryImage
-                ? provider.bytes.toString()
-                : "";
+            : provider is FileImage
+                ? provider.file.path
+                : provider is MemoryImage
+                    ? provider.bytes.toString()
+                    : "";
   }
 
   /// Calculates the [_frameIndex] based on the [AnimationController] value.


### PR DESCRIPTION
Due to file images not having unique keys, the caching was causing issues when the file path was changed on setState. The new image from the new path would not load at all. This PR fixes that issue and also allows disabling caching altogether using the `useCache` parameter.